### PR TITLE
fix: initialize none_opt with none instead of default constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ static_assert(x.is_some());
 
 // is_none
 constexpr opt::option<int> y = opt::none;
-// constexpr auto y = opt::none_opt<int>;
+// constexpr auto y = opt::none_opt<int>();
 static_assert(y.is_none());
 
 // is_some_and
@@ -262,7 +262,7 @@ constexpr auto x = opt::some("foo"s);
 constexpr auto y = x.ok_or("error"sv);
 static_assert(y.has_value() && y.value() == "foo");
 
-constexpr auto z = opt::none_opt<std::string>;
+constexpr auto z = opt::none_opt<std::string>();
 constexpr auto w = z.ok_or("error info"sv);
 static_assert(!w.has_value() && w.error() == "error info");
 
@@ -351,7 +351,7 @@ constexpr auto b = opt::some(2);
 constexpr auto zipped = a.zip(b);
 static_assert(zipped == opt::some(std::pair{ 1, 2 }));
 
-constexpr auto none_a = opt::none_opt<int>;
+constexpr auto none_a = opt::none_opt<int>();
 constexpr auto zipped2 = none_a.zip(b);
 static_assert(zipped2 == opt::none);
 
@@ -366,7 +366,7 @@ constexpr auto unzipped = pair_opt.unzip();
 static_assert(unzipped.first == opt::some(42));
 static_assert(unzipped.second == opt::some("hi"sv));
 
-constexpr auto none_pair = opt::none_opt<std::pair<int, std::string_view>>;
+constexpr auto none_pair = opt::none_opt<std::pair<int, std::string_view>>();
 constexpr auto unzipped2 = none_pair.unzip();
 static_assert(unzipped2.first == opt::none);
 static_assert(unzipped2.second == opt::none);
@@ -384,7 +384,7 @@ static_assert(unzipped2.second == opt::none);
 ```cpp
 constexpr auto a = opt::some(1);
 constexpr auto b = opt::some(2);
-constexpr auto n = opt::none_opt<int>;
+constexpr auto n = opt::none_opt<int>();
 
 // and_
 static_assert(a.and_(b) == b);

--- a/README_zh.md
+++ b/README_zh.md
@@ -149,7 +149,7 @@ static_assert(x.is_some());
 
 // is_none
 constexpr opt::option<int> y = opt::none;
-// constexpr auto y = opt::none_opt<int>;
+// constexpr auto y = opt::none_opt<int>();
 static_assert(y.is_none());
 
 // is_some_and
@@ -270,7 +270,7 @@ constexpr auto x = opt::some("foo"s);
 constexpr auto y = x.ok_or("error"sv);
 static_assert(y.has_value() && y.value() == "foo");
 
-constexpr auto z = opt::none_opt<std::string>;
+constexpr auto z = opt::none_opt<std::string>();
 constexpr auto w = z.ok_or("error info"sv);
 static_assert(!w.has_value() && w.error() == "error info");
 
@@ -361,7 +361,7 @@ constexpr auto b = opt::some(2);
 constexpr auto zipped = a.zip(b);
 static_assert(zipped == opt::some(std::pair{ 1, 2 }));
 
-constexpr auto none_a = opt::none_opt<int>;
+constexpr auto none_a = opt::none_opt<int>();
 constexpr auto zipped2 = none_a.zip(b);
 static_assert(zipped2 == opt::none);
 
@@ -376,7 +376,7 @@ constexpr auto unzipped = pair_opt.unzip();
 static_assert(unzipped.first == opt::some(42));
 static_assert(unzipped.second == opt::some("hi"sv));
 
-constexpr auto none_pair = opt::none_opt<std::pair<int, std::string_view>>;
+constexpr auto none_pair = opt::none_opt<std::pair<int, std::string_view>>();
 constexpr auto unzipped2 = none_pair.unzip();
 static_assert(unzipped2.first == opt::none);
 static_assert(unzipped2.second == opt::none);
@@ -395,7 +395,7 @@ static_assert(unzipped2.second == opt::none);
 ```cpp
 constexpr auto a = opt::some(1);
 constexpr auto b = opt::some(2);
-constexpr auto n = opt::none_opt<int>;
+constexpr auto n = opt::none_opt<int>();
 
 // and_
 static_assert(a.and_(b) == b);
@@ -744,7 +744,7 @@ std::println("组合: {}", combined);
 ### 创建
 - `opt::some(value)` —— 创建包含值的 option
 - `opt::none` —— 空 option
-- `opt::none_opt<T>` —— 创建类型为 T 的空 option
+- `opt::none_opt<T>()` —— 创建类型为 T 的空 option
 
 ### 典型用例
 ```cpp

--- a/src/include/option.hpp
+++ b/src/include/option.hpp
@@ -3176,7 +3176,9 @@ namespace opt {
     }
 
     template <typename T>
-    inline constexpr option<T> none_opt{ none };
+    constexpr option<T> none_opt() noexcept {
+        return option<T>{ none };
+    }
 
     template <typename T>
         requires (!detail::specialization_of<std::optional, T>)

--- a/src/include/option.hpp
+++ b/src/include/option.hpp
@@ -3176,7 +3176,7 @@ namespace opt {
     }
 
     template <typename T>
-    inline constexpr option<T> none_opt{};
+    inline constexpr option<T> none_opt{ none };
 
     template <typename T>
         requires (!detail::specialization_of<std::optional, T>)

--- a/src/test_unit.cpp
+++ b/src/test_unit.cpp
@@ -175,7 +175,7 @@ TEST(OptionBasic, PointerAdapter) {
 
     // Test none_opt<T*>()
     {
-        auto opt_none = none_opt<int *>;
+        auto opt_none = none_opt<int *>();
         EXPECT_TRUE(opt_none.is_none());
     }
 }
@@ -270,7 +270,7 @@ TEST(OptionEdge, PointerNullAndSentinel) {
     int v   = 1;
     auto o1 = some(&v);
     auto o2 = some<int *>(nullptr);
-    auto o3 = none_opt<int *>;
+    auto o3 = none_opt<int *>();
     EXPECT_TRUE(o1.is_some());
     EXPECT_EQ(o1.unwrap(), &v);
     EXPECT_TRUE(o2.is_some());
@@ -459,7 +459,7 @@ TEST(OptionEdge, XorZipWith) {
 TEST(OptionEdge, StaticMakeOptionNoneOpt) {
     auto a = make_option(1);
     EXPECT_EQ(a, some(1));
-    auto b = none_opt<double>;
+    auto b = none_opt<double>();
     EXPECT_TRUE(b.is_none());
 }
 
@@ -536,7 +536,7 @@ TEST(OptionAPI, PointerEdge) {
     int v                 = 7;
     opt::option<int *> o1 = opt::some(&v);
     opt::option<int *> o2 = opt::some<int *>(nullptr);
-    opt::option<int *> o3 = opt::none_opt<int *>;
+    opt::option<int *> o3 = opt::none_opt<int *>();
     EXPECT_TRUE(o1.is_some());
     EXPECT_TRUE(o2.is_some());
     EXPECT_TRUE(o3.is_none());
@@ -665,7 +665,7 @@ TEST(OptionAPI, CompareAll) {
 TEST(OptionAPI, StaticMakeOptionNoneOpt) {
     auto a = opt::make_option(1);
     EXPECT_EQ(a, opt::some(1));
-    auto b = opt::none_opt<double>;
+    auto b = opt::none_opt<double>();
     EXPECT_TRUE(b.is_none());
 }
 
@@ -730,7 +730,7 @@ constexpr opt::option<int> constexpr_some() {
     return opt::some(123);
 }
 constexpr opt::option<int> constexpr_none() {
-    return opt::none_opt<int>;
+    return opt::none_opt<int>();
 }
 static_assert(constexpr_some().is_some());
 static_assert(constexpr_none().is_none());


### PR DESCRIPTION
- Fixes GCC constexpr compilation error where none_opt<T>{} was not considered a constant expression
- Uses none_t to initialize none_opt<T> instead of default constructor
- Resolves error: 'opt::option<T>()' is not a constant expression because it refers to an incompletely initialized variable